### PR TITLE
Add typed accounts domain module and wire finance account screens

### DIFF
--- a/apps/native/app/(tabs)/finance/accounts/[id]/delete.tsx
+++ b/apps/native/app/(tabs)/finance/accounts/[id]/delete.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ScrollView, StyleSheet } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import {
@@ -13,6 +13,7 @@ import {
   Text,
   View,
 } from "@/components";
+import { deleteAccount, getAccount, type Account, type DeleteAccountPayload } from "@/lib/accounts";
 import { NAV_THEME, Typography, UI_PRESETS } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 
@@ -22,32 +23,81 @@ export default function DeleteAccountScreen() {
   const { colorScheme } = useColorScheme();
   const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
 
+  const [account, setAccount] = useState<Account | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const [isDeleting, setIsDeleting] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
-  const [hasError, setHasError] = useState(id === "error");
-  const [notFound] = useState(!id);
+  const [error, setError] = useState<string | null>(null);
 
-  const onDelete = () => {
+  useEffect(() => {
+    async function load() {
+      if (!id) {
+        setError("Account ID is missing.");
+        setIsLoading(false);
+        return;
+      }
+
+      const found = await getAccount(id);
+      setAccount(found);
+      setIsLoading(false);
+
+      if (!found) {
+        setError("Account not found.");
+      }
+    }
+
+    void load();
+  }, [id]);
+
+  const onDelete = async () => {
+    if (!id) {
+      setError("Account ID is missing.");
+      return;
+    }
+
     setShowDialog(false);
     setIsDeleting(true);
-    setTimeout(() => {
-      setIsDeleting(false);
+    setError(null);
+
+    try {
+      const payload: DeleteAccountPayload = {
+        id,
+        hardDelete: false,
+      };
+
+      const success = await deleteAccount(payload);
+      if (!success) {
+        setError("Deletion failed. Try again.");
+        return;
+      }
+
       router.replace("/(tabs)/finance/accounts" as any);
-    }, 900);
+    } finally {
+      setIsDeleting(false);
+    }
   };
+
+  const notFound = !isLoading && !account;
 
   return (
     <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
       <SectionHeader title="Delete Account" subtitle={`Account ID: ${id ?? "unknown"}`} />
 
-      {hasError ? (
+      {error ? (
         <Banner
           variant="error"
           title="Deletion failed"
-          message="Try again, or cancel and review linked transactions first."
+          message={error}
           actionLabel="Retry"
-          onActionPress={() => setHasError(false)}
+          onActionPress={() => setError(null)}
         />
+      ) : null}
+
+      {isLoading ? (
+        <View style={styles.deletingState}>
+          <Spinner />
+          <Text style={[Typography.bodySM, { color: theme.mutedForeground }]}>Loading account…</Text>
+        </View>
       ) : null}
 
       {notFound ? (
@@ -57,12 +107,12 @@ export default function DeleteAccountScreen() {
           actionLabel="Back to accounts"
           onActionPress={() => router.replace("/(tabs)/finance/accounts" as any)}
         />
-      ) : (
+      ) : null}
+
+      {!isLoading && account ? (
         <Card variant="outline" style={[styles.confirmCard, { borderColor: theme.border }]}>
-          <Text style={[Typography.titleSM, { color: theme.text }]}>Delete this account permanently?</Text>
-          <Text style={[Typography.bodySM, { color: theme.mutedForeground }]}>
-            This action removes the account and disconnects it from future reconciliation workflows.
-          </Text>
+          <Text style={[Typography.titleSM, { color: theme.text }]}>Archive {account.name}?</Text>
+          <Text style={[Typography.bodySM, { color: theme.mutedForeground }]}>This action archives the account for history.</Text>
 
           <Alert
             variant="error"
@@ -87,7 +137,7 @@ export default function DeleteAccountScreen() {
             />
           </View>
         </Card>
-      )}
+      ) : null}
 
       <Dialog
         visible={showDialog}

--- a/apps/native/app/(tabs)/finance/accounts/[id]/update.tsx
+++ b/apps/native/app/(tabs)/finance/accounts/[id]/update.tsx
@@ -1,34 +1,107 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { StyleSheet } from "react-native";
-import { AccountForm, Text, View, type AccountFormValues } from "@/components";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { AccountForm, Banner, Button, Spinner, Text, View, type AccountFormValues } from "@/components";
+import { getAccount, updateAccount, type Account, type UpdateAccountPayload } from "@/lib/accounts";
 import { NAV_THEME, Typography, UI_PRESETS } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 
 export default function UpdateAccount() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
   const { colorScheme } = useColorScheme();
   const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
-  const [loading, setLoading] = useState(false);
 
-  const handleUpdate = async (_values: AccountFormValues) => {
+  const [account, setAccount] = useState<Account | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      if (!id) {
+        setIsLoading(false);
+        setError("Account ID is missing.");
+        return;
+      }
+
+      const found = await getAccount(id);
+      setAccount(found);
+      setIsLoading(false);
+
+      if (!found) {
+        setError("Account not found.");
+      }
+    }
+
+    void load();
+  }, [id]);
+
+  const handleUpdate = async (values: AccountFormValues) => {
+    if (!id) {
+      setError("Account ID is missing.");
+      return;
+    }
+
     setLoading(true);
-    setLoading(false);
+    setError(null);
+
+    try {
+      const payload: UpdateAccountPayload = {
+        name: values.name,
+        type: values.type,
+        status: values.isActive ? "active" : "archived",
+        balance: Number(values.balance),
+      };
+
+      const updated = await updateAccount(id, payload);
+      setAccount(updated);
+
+      if (!updated) {
+        setError("Unable to update account.");
+      }
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <View style={[styles.screen, { backgroundColor: theme.background }]}>
       <Text style={[styles.title, { color: theme.foreground }]}>Update Account</Text>
-      <AccountForm
-        mode="update"
-        submitLabel="Save changes"
-        loading={loading}
-        initialValues={{
-          name: "Primary Checking",
-          balance: "2500.00",
-          type: "checking",
-          isActive: true,
-        }}
-        onSubmit={handleUpdate}
-      />
+
+      {error ? (
+        <Banner
+          variant="error"
+          title="Update issue"
+          message={error}
+          actionLabel="Back"
+          onActionPress={() => router.replace("/(tabs)/finance/accounts" as any)}
+        />
+      ) : null}
+
+      {isLoading ? (
+        <View style={styles.loadingState}>
+          <Spinner />
+          <Text style={[Typography.bodySM, { color: theme.mutedForeground }]}>Loading account…</Text>
+        </View>
+      ) : null}
+
+      {!isLoading && account ? (
+        <AccountForm
+          mode="update"
+          submitLabel="Save changes"
+          loading={loading}
+          initialValues={{
+            name: account.name,
+            balance: `${account.balance}`,
+            type: account.type,
+            isActive: account.status === "active",
+          }}
+          onSubmit={handleUpdate}
+        />
+      ) : null}
+
+      <Button title="Back to accounts" variant="outline" onPress={() => router.replace("/(tabs)/finance/accounts" as any)} />
     </View>
   );
 }
@@ -41,6 +114,12 @@ const styles = StyleSheet.create({
   },
   title: {
     ...Typography.titleLG,
+    paddingHorizontal: UI_PRESETS.spacing.section,
+  },
+  loadingState: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: UI_PRESETS.spacing.sm,
     paddingHorizontal: UI_PRESETS.spacing.section,
   },
 });

--- a/apps/native/app/(tabs)/finance/accounts/create.tsx
+++ b/apps/native/app/(tabs)/finance/accounts/create.tsx
@@ -1,23 +1,52 @@
 import React, { useState } from "react";
 import { StyleSheet } from "react-native";
-import { AccountForm, Text, View, type AccountFormValues } from "@/components";
+import { useRouter } from "expo-router";
+import { AccountForm, Button, Card, Text, View, type AccountFormValues } from "@/components";
+import { createAccount, formatAccountBalance, type Account, type CreateAccountPayload } from "@/lib/accounts";
 import { NAV_THEME, Typography, UI_PRESETS } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 
 export default function CreateAccount() {
   const { colorScheme } = useColorScheme();
   const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
+  const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const [created, setCreated] = useState<Account | null>(null);
 
-  const handleCreate = async (_values: AccountFormValues) => {
+  const handleCreate = async (values: AccountFormValues) => {
     setLoading(true);
-    setLoading(false);
+
+    try {
+      const payload: CreateAccountPayload = {
+        name: values.name,
+        type: values.type,
+        openingBalance: Number(values.balance),
+        currencyCode: "GHS",
+      };
+
+      const account = await createAccount(payload);
+      setCreated(account);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <View style={[styles.screen, { backgroundColor: theme.background }]}>
       <Text style={[styles.title, { color: theme.foreground }]}>Create Account</Text>
       <AccountForm mode="create" submitLabel="Create account" loading={loading} onSubmit={handleCreate} />
+
+      {created ? (
+        <Card variant="outline" style={[styles.summaryCard, { borderColor: theme.border }]}>
+          <Text style={[Typography.labelSM, { color: theme.mutedForeground }]}>Created</Text>
+          <Text style={[Typography.bodyMD, { color: theme.text }]}>{created.name}</Text>
+          <Text style={[Typography.captionSM, { color: theme.mutedForeground }]}>
+            {formatAccountBalance(created.balance, created.currencyCode)}
+          </Text>
+        </Card>
+      ) : null}
+
+      <Button title="Back to accounts" variant="outline" onPress={() => router.replace("/(tabs)/finance/accounts" as any)} />
     </View>
   );
 }
@@ -31,5 +60,9 @@ const styles = StyleSheet.create({
   title: {
     ...Typography.titleLG,
     paddingHorizontal: UI_PRESETS.spacing.section,
+  },
+  summaryCard: {
+    gap: UI_PRESETS.spacing.xs,
+    marginHorizontal: UI_PRESETS.spacing.section,
   },
 });

--- a/apps/native/app/(tabs)/finance/accounts/index.tsx
+++ b/apps/native/app/(tabs)/finance/accounts/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ScrollView, StyleSheet } from "react-native";
 import { useRouter } from "expo-router";
 import {
@@ -12,43 +12,13 @@ import {
   Text,
   View,
 } from "@/components";
+import { formatAccountStatus, listAccounts, mapAccountListItem, type Account } from "@/lib/accounts";
 import { NAV_THEME, Typography, UI_PRESETS } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 
-type Account = {
-  id: string;
-  name: string;
-  institution: string;
-  type: "Checking" | "Savings" | "Credit Card" | "Brokerage";
-  currency: string;
-  status: "Active" | "Inactive";
-  balance: number;
-};
-
-const sampleAccounts: Account[] = [
-  {
-    id: "acc-001",
-    name: "Daily Spending",
-    institution: "Northstar Bank",
-    type: "Checking",
-    currency: "USD",
-    status: "Active",
-    balance: 4821.34,
-  },
-  {
-    id: "acc-002",
-    name: "Emergency Fund",
-    institution: "Northstar Bank",
-    type: "Savings",
-    currency: "USD",
-    status: "Active",
-    balance: 14550.22,
-  },
-];
-
 const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",
-  currency: "USD",
+  currency: "GHS",
 });
 
 export default function AccountsIndexScreen() {
@@ -60,28 +30,28 @@ export default function AccountsIndexScreen() {
   const [hasError, setHasError] = useState(false);
   const [accounts, setAccounts] = useState<Account[]>([]);
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setAccounts(sampleAccounts);
-      setIsLoading(false);
-    }, 450);
+  const refreshAccounts = useCallback(async () => {
+    setHasError(false);
+    setIsLoading(true);
 
-    return () => clearTimeout(timer);
+    try {
+      const nextAccounts = await listAccounts();
+      setAccounts(nextAccounts);
+    } catch {
+      setHasError(true);
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    void refreshAccounts();
+  }, [refreshAccounts]);
 
   const totalBalance = useMemo(
     () => accounts.reduce((sum, account) => sum + account.balance, 0),
     [accounts],
   );
-
-  const retry = () => {
-    setHasError(false);
-    setIsLoading(true);
-    setTimeout(() => {
-      setAccounts(sampleAccounts);
-      setIsLoading(false);
-    }, 450);
-  };
 
   const showEmptyState = !isLoading && !hasError && accounts.length === 0;
 
@@ -107,7 +77,9 @@ export default function AccountsIndexScreen() {
           title="Unable to load accounts"
           message="Please check your connection and try again."
           actionLabel="Retry"
-          onActionPress={retry}
+          onActionPress={() => {
+            void refreshAccounts();
+          }}
         />
       ) : null}
 
@@ -131,19 +103,44 @@ export default function AccountsIndexScreen() {
         <Card variant="outline" style={[styles.listCard, { borderColor: theme.border }]}>
           <SectionHeader title="Linked Accounts" subtitle={`${accounts.length} total`} />
           <View style={styles.list}>
-            {accounts.map((account) => (
-              <ListItem
-                key={account.id}
-                title={account.name}
-                subtitle={`${account.institution} · ${account.type} · ${account.currency}`}
-                meta={currencyFormatter.format(account.balance)}
-                onPress={() => router.push(`/(tabs)/finance/accounts/${account.id}/update` as any)}
-                right={<Text style={[Typography.captionSM, { color: theme.mutedForeground }]}>{account.status}</Text>}
-                style={styles.listItem}
-              />
-            ))}
+            {accounts.map((account) => {
+              const mapped = mapAccountListItem(account);
+
+              return (
+                <ListItem
+                  key={mapped.id}
+                  title={mapped.title}
+                  subtitle={mapped.subtitle}
+                  meta={mapped.balanceLabel}
+                  onPress={() => router.push(`/(tabs)/finance/accounts/${account.id}/update` as any)}
+                  right={
+                    <Text style={[Typography.captionSM, { color: theme.mutedForeground }]}>
+                      {formatAccountStatus(account.status)}
+                    </Text>
+                  }
+                  style={styles.listItem}
+                />
+              );
+            })}
           </View>
         </Card>
+      ) : null}
+
+      {!isLoading && !hasError && accounts[0] ? (
+        <View style={styles.actionsRow}>
+          <Button
+            title="Edit First Account"
+            variant="outline"
+            style={styles.actionButton}
+            onPress={() => router.push(`/(tabs)/finance/accounts/${accounts[0].id}/update` as any)}
+          />
+          <Button
+            title="Delete First Account"
+            variant="destructive"
+            style={styles.actionButton}
+            onPress={() => router.push(`/(tabs)/finance/accounts/${accounts[0].id}/delete` as any)}
+          />
+        </View>
       ) : null}
 
       {!isLoading && !hasError ? (
@@ -161,7 +158,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: UI_PRESETS.spacing.screen,
     paddingBottom: UI_PRESETS.spacing.section,
     gap: UI_PRESETS.spacing.xl,
-    paddingTop: UI_PRESETS.spacing.screen
+    paddingTop: UI_PRESETS.spacing.screen,
   },
   summaryCard: {
     gap: UI_PRESETS.spacing.sm,
@@ -183,5 +180,12 @@ const styles = StyleSheet.create({
   },
   listItem: {
     borderRadius: UI_PRESETS.radius.md,
+  },
+  actionsRow: {
+    flexDirection: "row",
+    gap: UI_PRESETS.spacing.sm,
+  },
+  actionButton: {
+    flex: 1,
   },
 });

--- a/apps/native/app/(tabs)/finance/index.tsx
+++ b/apps/native/app/(tabs)/finance/index.tsx
@@ -13,9 +13,11 @@ import {
 import { Pressable, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 import { StyleSheet } from "react-native";
+import React, { useEffect, useState } from "react";
 
 import { NAV_THEME, Typography, CardTokens, UI_PRESETS } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
+import { listAccounts } from "@/lib/accounts";
 
 const OPACITY = {
   pressed: 0.84,
@@ -83,25 +85,39 @@ const sampleDebts: DebtItem[] = [
   },
 ];
 
-const sampleAccountOverview: AccountOverviewMetrics = {
-  totalCash: 18345.79,
-  moneyInMtd: 8950.0,
-  moneyOutMtd: 6124.45,
-  accountsCount: 5,
-  periodLabel: "Mar 2026 · Month-to-date",
-};
-
 export default function Index() {
   const router = useRouter();
   const { colorScheme } = useColorScheme();
   const theme = colorScheme === "dark" ? NAV_THEME.dark : NAV_THEME.light;
+  const [accountOverview, setAccountOverview] = useState<AccountOverviewMetrics>({
+    totalCash: 0,
+    moneyInMtd: 8950,
+    moneyOutMtd: 6124.45,
+    accountsCount: 0,
+    periodLabel: "Mar 2026 · Month-to-date",
+  });
+
+  useEffect(() => {
+    async function loadAccountOverview() {
+      const accounts = await listAccounts();
+      const totalCash = accounts.reduce((sum, account) => sum + account.balance, 0);
+
+      setAccountOverview((previous) => ({
+        ...previous,
+        totalCash,
+        accountsCount: accounts.length,
+      }));
+    }
+
+    void loadAccountOverview();
+  }, []);
 
   const navItems = [
     {
       key: "accounting",
       badge: "AC",
       label: "Accounts",
-      meta: "Tracked accounts: 0",
+      meta: `Tracked accounts: ${accountOverview.accountsCount}`,
       route: "/(tabs)/finance/accounts",
     },
     {
@@ -148,7 +164,7 @@ export default function Index() {
       {/*<View>*/}
       <SectionHeader title="Overview" subtitle="MONTHLY SNAPSHOT" />
       <AccountOverviewCard
-        metrics={sampleAccountOverview}
+        metrics={accountOverview}
         onViewAccountsPress={() => router.push("/(tabs)/finance/accounts" as any)}
       />
       <OverviewChartCard />

--- a/apps/native/components/account-form.tsx
+++ b/apps/native/components/account-form.tsx
@@ -10,7 +10,7 @@ import { NAV_THEME, Typography, UI_PRESETS } from "@/lib/constants";
 import { useColorScheme } from "@/lib/use-color-scheme";
 
 export type AccountFormMode = "create" | "update";
-export type AccountType = "checking" | "savings";
+export type AccountType = "checking" | "savings" | "credit" | "cash";
 
 export interface AccountFormValues {
   name: string;
@@ -131,6 +131,8 @@ export function AccountForm({
         <View style={styles.chipRow}>
           <Chip label="Checking" selected={type === "checking"} onSelect={() => setType("checking")} />
           <Chip label="Savings" selected={type === "savings"} onSelect={() => setType("savings")} />
+          <Chip label="Credit" selected={type === "credit"} onSelect={() => setType("credit")} />
+          <Chip label="Cash" selected={type === "cash"} onSelect={() => setType("cash")} />
         </View>
       </View>
 

--- a/apps/native/lib/accounts/formatters.ts
+++ b/apps/native/lib/accounts/formatters.ts
@@ -1,0 +1,59 @@
+import type { Account, AccountStatus, AccountType } from "./types";
+
+const ACCOUNT_TYPE_LABELS: Record<AccountType, string> = {
+  checking: "Checking",
+  savings: "Savings",
+  credit: "Credit",
+  cash: "Cash",
+};
+
+const ACCOUNT_STATUS_LABELS: Record<AccountStatus, string> = {
+  active: "Active",
+  archived: "Archived",
+  closed: "Closed",
+};
+
+function getCurrencySymbol(currencyCode: string): string {
+  switch (currencyCode.toUpperCase()) {
+    case "GHS":
+      return "GH₵";
+    case "USD":
+      return "$";
+    case "EUR":
+      return "€";
+    case "GBP":
+      return "£";
+    default:
+      return `${currencyCode.toUpperCase()} `;
+  }
+}
+
+export function formatAccountBalance(balance: number, currencyCode: string): string {
+  const symbol = getCurrencySymbol(currencyCode);
+  return `${symbol}${balance.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+export function formatAccountType(type: AccountType): string {
+  return ACCOUNT_TYPE_LABELS[type];
+}
+
+export function formatAccountStatus(status: AccountStatus): string {
+  return ACCOUNT_STATUS_LABELS[status];
+}
+
+export function mapAccountListItem(account: Account): {
+  id: string;
+  title: string;
+  subtitle: string;
+  balanceLabel: string;
+} {
+  return {
+    id: account.id,
+    title: account.name,
+    subtitle: `${formatAccountType(account.type)} · ${formatAccountStatus(account.status)}`,
+    balanceLabel: formatAccountBalance(account.balance, account.currencyCode),
+  };
+}

--- a/apps/native/lib/accounts/index.ts
+++ b/apps/native/lib/accounts/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./repository";
+export * from "./formatters";

--- a/apps/native/lib/accounts/repository.ts
+++ b/apps/native/lib/accounts/repository.ts
@@ -1,0 +1,104 @@
+import type {
+  Account,
+  CreateAccountPayload,
+  DeleteAccountPayload,
+  UpdateAccountPayload,
+} from "./types";
+
+let accountsStore: Account[] = [
+  {
+    id: "acc-1",
+    name: "Main Checking",
+    type: "checking",
+    status: "active",
+    currencyCode: "GHS",
+    balance: 12450.75,
+    note: "Payroll and day-to-day spending",
+    createdAt: "2026-03-01T08:00:00.000Z",
+    updatedAt: "2026-03-01T08:00:00.000Z",
+  },
+  {
+    id: "acc-2",
+    name: "Emergency Savings",
+    type: "savings",
+    status: "active",
+    currencyCode: "GHS",
+    balance: 5895.04,
+    note: "3-month reserve",
+    createdAt: "2026-02-16T08:00:00.000Z",
+    updatedAt: "2026-02-16T08:00:00.000Z",
+  },
+];
+
+function nextAccountId(): string {
+  return `acc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export async function listAccounts(): Promise<Account[]> {
+  return [...accountsStore];
+}
+
+export async function getAccount(accountId: string): Promise<Account | null> {
+  return accountsStore.find((account) => account.id === accountId) ?? null;
+}
+
+export async function createAccount(payload: CreateAccountPayload): Promise<Account> {
+  const now = new Date().toISOString();
+
+  const account: Account = {
+    id: nextAccountId(),
+    name: payload.name,
+    type: payload.type,
+    status: "active",
+    currencyCode: payload.currencyCode ?? "GHS",
+    balance: payload.openingBalance ?? 0,
+    note: payload.note,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  accountsStore = [account, ...accountsStore];
+
+  return account;
+}
+
+export async function updateAccount(
+  accountId: string,
+  payload: UpdateAccountPayload
+): Promise<Account | null> {
+  const currentAccount = accountsStore.find((account) => account.id === accountId);
+  if (!currentAccount) {
+    return null;
+  }
+
+  const updatedAccount: Account = {
+    ...currentAccount,
+    ...payload,
+    updatedAt: new Date().toISOString(),
+  };
+
+  accountsStore = accountsStore.map((account) => (account.id === accountId ? updatedAccount : account));
+
+  return updatedAccount;
+}
+
+export async function deleteAccount(payload: DeleteAccountPayload): Promise<boolean> {
+  const index = accountsStore.findIndex((account) => account.id === payload.id);
+  if (index < 0) {
+    return false;
+  }
+
+  if (payload.hardDelete) {
+    accountsStore = accountsStore.filter((account) => account.id !== payload.id);
+    return true;
+  }
+
+  const account = accountsStore[index];
+  accountsStore[index] = {
+    ...account,
+    status: "archived",
+    updatedAt: new Date().toISOString(),
+  };
+
+  return true;
+}

--- a/apps/native/lib/accounts/types.ts
+++ b/apps/native/lib/accounts/types.ts
@@ -1,0 +1,37 @@
+export type AccountType = "checking" | "savings" | "credit" | "cash";
+
+export type AccountStatus = "active" | "archived" | "closed";
+
+export interface Account {
+  id: string;
+  name: string;
+  type: AccountType;
+  status: AccountStatus;
+  currencyCode: string;
+  balance: number;
+  note?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAccountPayload {
+  name: string;
+  type: AccountType;
+  currencyCode?: string;
+  openingBalance?: number;
+  note?: string;
+}
+
+export interface UpdateAccountPayload {
+  name?: string;
+  type?: AccountType;
+  status?: AccountStatus;
+  currencyCode?: string;
+  balance?: number;
+  note?: string;
+}
+
+export interface DeleteAccountPayload {
+  id: string;
+  hardDelete?: boolean;
+}


### PR DESCRIPTION
### Motivation
- Provide a small, typed accounts domain so account contracts and logic are centralized and reusable across the native app.
- Replace ad-hoc inline account state in screens with typed repository APIs to improve maintainability and enable clearer UI contracts.
- Add formatting/mapping utilities that match existing currency display patterns used in `account-overview-card.tsx`.

### Description
- Added a new domain module at `apps/native/lib/accounts/` with `types.ts` (types/DTOs), `repository.ts` (in-memory `listAccounts`, `getAccount`, `createAccount`, `updateAccount`, `deleteAccount`), `formatters.ts` (currency/label formatters and `mapAccountListItem`), and `index.ts` barrel exports.
- Implemented repository functions with explicit async return types and a small in-memory sample store to support UI flows and soft/hard delete semantics via `DeleteAccountPayload`.
- Wired screens under `apps/native/app/(tabs)/finance/accounts/` (`index.tsx`, `create.tsx`, `[id]/update.tsx`, `[id]/delete.tsx`) to consume the new typed APIs and formatters instead of placeholder inline content.
- Updated the finance overview at `apps/native/app/(tabs)/finance/index.tsx` to derive `totalCash` and `accountsCount` from `listAccounts()` and surface the count in quick-nav metadata and the overview card.

### Testing
- Ran a targeted TypeScript check on the new accounts module with `bunx tsc --noEmit --target es2020 --module esnext --lib es2020 apps/native/lib/accounts/*.ts` which succeeded for the added files.
- Attempted full project type checking via `bun run check-types` but it failed in this environment because `turbo` is not available on PATH.
- Attempted to start the Expo web server (`cd apps/native && bunx expo start --web --non-interactive --port 8081`) but resolving `expo` failed with an HTTP 403 from the npm registry in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a535ad2ac08321a02820a6bbe6b0dc)