### PR TITLE
Improve finance accounts route context and CRUD UX feedback

### DIFF
--- a/apps/native/app/(tabs)/finance/accounts/[id]/_layout.tsx
+++ b/apps/native/app/(tabs)/finance/accounts/[id]/_layout.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Stack } from "expo-router";
+
+import { RouteAccountProvider } from "./route-context";
+
+export default function AccountIdLayout() {
+  return (
+    <RouteAccountProvider>
+      <Stack screenOptions={{ headerShown: false }} />
+    </RouteAccountProvider>
+  );
+}

--- a/apps/native/app/(tabs)/finance/accounts/[id]/delete.tsx
+++ b/apps/native/app/(tabs)/finance/accounts/[id]/delete.tsx
@@ -1,10 +1,108 @@
-import { View, Text } from "@/components";
-import React from "react";
+import React, { useState } from "react";
+import { StyleSheet } from "react-native";
+import { router } from "expo-router";
+import { toast } from "sonner-native";
+
+import { Alert, Button, Dialog, Text, View } from "@/components";
+import { UI_PRESETS } from "@/lib/constants";
+import { deleteAccount } from "../data";
+import { useRouteAccount } from "./route-context";
 
 export default function DeleteAccount() {
+  const { account, accountId, isLoading, error } = useRouteAccount();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const handleDelete = async () => {
+    if (isDeleting) {
+      return;
+    }
+
+    setIsDeleting(true);
+
+    try {
+      const deleted = await deleteAccount(accountId);
+      toast.success("Account deleted", {
+        description: `${deleted.name} was removed.`,
+      });
+      router.replace("/(tabs)/finance/accounts");
+    } catch {
+      toast.error("Delete failed", {
+        description: "This account may have already been removed.",
+      });
+      setIsDeleting(false);
+      setConfirmOpen(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <View style={styles.screen}>
+        <Text>Loading account…</Text>
+      </View>
+    );
+  }
+
+  if (!account) {
+    return (
+      <View style={styles.screen}>
+        <Alert
+          variant="warning"
+          title="Account unavailable"
+          message={error ?? "This account no longer exists."}
+          actionLabel="Back to accounts"
+          onActionPress={() => router.replace("/(tabs)/finance/accounts")}
+        />
+      </View>
+    );
+  }
+
   return (
-    <View>
-      <Text>DeleteAccount</Text>
+    <View style={styles.screen}>
+      <Text style={styles.title}>Delete account</Text>
+
+      <Alert
+        variant="warning"
+        title="You're about to permanently delete this account"
+        message={`${account.name} · ${account.type.toUpperCase()} · ${account.currency} ${account.balance.toFixed(2)}\nLast updated ${new Date(account.updatedAt).toLocaleString()}`}
+      />
+
+      <View style={isDeleting ? styles.disabledBlock : undefined}>
+        <Button
+          title="Confirm deletion"
+          variant="destructive"
+          onPress={() => setConfirmOpen(true)}
+          disabled={isDeleting}
+        />
+      </View>
+
+      <Button title="Cancel" variant="ghost" onPress={() => router.back()} disabled={isDeleting} />
+
+      <Dialog
+        visible={confirmOpen}
+        title={`Delete ${account.name}?`}
+        description={`${account.type.toUpperCase()} account with ${account.currency} ${account.balance.toFixed(2)} will be permanently removed.`}
+        tone="destructive"
+        confirmLabel="Delete now"
+        cancelLabel="Keep account"
+        onCancel={() => !isDeleting && setConfirmOpen(false)}
+        onConfirm={handleDelete}
+      />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    padding: UI_PRESETS.spacing.screen,
+    gap: UI_PRESETS.spacing.lg,
+  },
+  title: {
+    fontFamily: "Geist",
+    fontSize: 22,
+  },
+  disabledBlock: {
+    opacity: UI_PRESETS.opacity.disabled,
+  },
+});

--- a/apps/native/app/(tabs)/finance/accounts/[id]/route-context.tsx
+++ b/apps/native/app/(tabs)/finance/accounts/[id]/route-context.tsx
@@ -1,0 +1,79 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { useLocalSearchParams } from "expo-router";
+
+import { getAccountById, type AccountRecord } from "../data";
+
+type RouteAccountContextValue = {
+  accountId: string;
+  account: AccountRecord | null;
+  isLoading: boolean;
+  error: string | null;
+  refreshAccount: () => Promise<void>;
+};
+
+const RouteAccountContext = createContext<RouteAccountContextValue | null>(null);
+
+export function RouteAccountProvider({ children }: { children: React.ReactNode }) {
+  const params = useLocalSearchParams<{ id?: string | string[] }>();
+  const accountId = Array.isArray(params.id) ? params.id[0] ?? "" : params.id ?? "";
+
+  const [account, setAccount] = useState<AccountRecord | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshAccount = async () => {
+    if (!accountId) {
+      setAccount(null);
+      setError("Missing account id.");
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const nextAccount = await getAccountById(accountId);
+
+      if (!nextAccount) {
+        setAccount(null);
+        setError("This account no longer exists.");
+        return;
+      }
+
+      setAccount(nextAccount);
+      setError(null);
+    } catch {
+      setAccount(null);
+      setError("Unable to load account details right now.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refreshAccount();
+  }, [accountId]);
+
+  const value = useMemo<RouteAccountContextValue>(
+    () => ({
+      account,
+      accountId,
+      isLoading,
+      error,
+      refreshAccount,
+    }),
+    [account, accountId, error, isLoading],
+  );
+
+  return <RouteAccountContext.Provider value={value}>{children}</RouteAccountContext.Provider>;
+}
+
+export function useRouteAccount() {
+  const value = useContext(RouteAccountContext);
+
+  if (!value) {
+    throw new Error("useRouteAccount must be used inside RouteAccountProvider");
+  }
+
+  return value;
+}

--- a/apps/native/app/(tabs)/finance/accounts/[id]/update.tsx
+++ b/apps/native/app/(tabs)/finance/accounts/[id]/update.tsx
@@ -1,10 +1,119 @@
-import { View, Text } from "@/components";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { StyleSheet } from "react-native";
+import { router } from "expo-router";
+import { toast } from "sonner-native";
+
+import { Alert, Button, Input, Text, View } from "@/components";
+import { UI_PRESETS } from "@/lib/constants";
+import { updateAccount } from "../data";
+import { useRouteAccount } from "./route-context";
 
 export default function UpdateAccount() {
+  const { account, accountId, isLoading, error } = useRouteAccount();
+
+  const [name, setName] = useState("");
+  const [balance, setBalance] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!account) {
+      return;
+    }
+
+    setName(account.name);
+    setBalance(String(account.balance));
+  }, [account]);
+
+  const canSubmit = name.trim().length > 1 && Number.isFinite(Number(balance));
+
+  const handleUpdate = async () => {
+    if (!canSubmit || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await updateAccount(accountId, {
+        name: name.trim(),
+        balance: Number(balance),
+      });
+
+      toast.success("Account updated", {
+        description: `${name.trim()} has been saved.`,
+      });
+
+      router.replace("/(tabs)/finance/accounts");
+    } catch {
+      toast.error("Update failed", {
+        description: "That account could not be updated.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <View style={styles.screen}>
+        <Text>Loading account…</Text>
+      </View>
+    );
+  }
+
+  if (!account) {
+    return (
+      <View style={styles.screen}>
+        <Alert
+          variant="warning"
+          title="Account unavailable"
+          message={error ?? "This account was deleted or cannot be loaded."}
+          actionLabel="Back to accounts"
+          onActionPress={() => router.replace("/(tabs)/finance/accounts")}
+        />
+      </View>
+    );
+  }
+
   return (
-    <View>
-      <Text>UpdateAccount</Text>
+    <View style={styles.screen}>
+      <Text style={styles.title}>Update account</Text>
+      <Text style={styles.meta}>Editing: {account.id}</Text>
+
+      <View style={[styles.form, isSubmitting && styles.disabledBlock]}>
+        <Input value={name} onChangeText={setName} editable={!isSubmitting} />
+        <Input value={balance} onChangeText={setBalance} editable={!isSubmitting} keyboardType="decimal-pad" />
+      </View>
+
+      <Button title="Update" onPress={handleUpdate} disabled={!canSubmit} loading={isSubmitting} />
+      <Button
+        title="Delete account"
+        variant="destructive"
+        onPress={() => router.push(`/(tabs)/finance/accounts/${account.id}/delete`)}
+        disabled={isSubmitting}
+      />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    padding: UI_PRESETS.spacing.screen,
+    gap: UI_PRESETS.spacing.lg,
+  },
+  title: {
+    fontFamily: "Geist",
+    fontSize: 22,
+  },
+  meta: {
+    fontFamily: "Figtree",
+    opacity: UI_PRESETS.opacity.muted,
+  },
+  form: {
+    gap: UI_PRESETS.spacing.md,
+  },
+  disabledBlock: {
+    opacity: UI_PRESETS.opacity.disabled,
+  },
+});

--- a/apps/native/app/(tabs)/finance/accounts/create.tsx
+++ b/apps/native/app/(tabs)/finance/accounts/create.tsx
@@ -1,10 +1,90 @@
-import { View, Text } from "@/components";
-import React from "react";
+import React, { useState } from "react";
+import { StyleSheet } from "react-native";
+import { router } from "expo-router";
+import { toast } from "sonner-native";
+
+import { Alert, Button, Input, Text, View } from "@/components";
+import { UI_PRESETS } from "@/lib/constants";
+import { createAccount } from "./data";
 
 export default function CreateAccount() {
+  const [name, setName] = useState("");
+  const [balance, setBalance] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const canSubmit = name.trim().length > 1 && Number.isFinite(Number(balance));
+
+  const handleSubmit = async () => {
+    if (!canSubmit || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await createAccount({
+        name: name.trim(),
+        balance: Number(balance),
+        type: "checking",
+        currency: "USD",
+      });
+
+      toast.success("Account created", {
+        description: `${name.trim()} is ready to use.`,
+      });
+
+      router.replace("/(tabs)/finance/accounts");
+    } catch {
+      toast.error("Could not create account", {
+        description: "Please try again.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
-    <View>
-      <Text>CreateAccount</Text>
+    <View style={styles.screen}>
+      <Text style={styles.title}>Create account</Text>
+      <Alert
+        variant="info"
+        title="Tip"
+        message="You'll be redirected to Accounts after a successful save."
+      />
+      <View style={[styles.form, isSubmitting && styles.disabledBlock]}>
+        <Input
+          value={name}
+          onChangeText={setName}
+          editable={!isSubmitting}
+          placeholder="Account name"
+        />
+        <Input
+          value={balance}
+          onChangeText={setBalance}
+          editable={!isSubmitting}
+          keyboardType="decimal-pad"
+          placeholder="Starting balance"
+        />
+      </View>
+      <Button title="Save account" onPress={handleSubmit} disabled={!canSubmit} loading={isSubmitting} />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    padding: UI_PRESETS.spacing.screen,
+    gap: UI_PRESETS.spacing.lg,
+  },
+  title: {
+    fontFamily: "Geist",
+    fontSize: 22,
+  },
+  form: {
+    gap: UI_PRESETS.spacing.md,
+  },
+  disabledBlock: {
+    opacity: UI_PRESETS.opacity.disabled,
+  },
+});

--- a/apps/native/app/(tabs)/finance/accounts/data.ts
+++ b/apps/native/app/(tabs)/finance/accounts/data.ts
@@ -1,0 +1,85 @@
+export type AccountRecord = {
+  id: string;
+  name: string;
+  type: "checking" | "savings" | "credit";
+  balance: number;
+  currency: string;
+  updatedAt: string;
+};
+
+let accounts: AccountRecord[] = [
+  {
+    id: "acc-1",
+    name: "Everyday Checking",
+    type: "checking",
+    balance: 2480.12,
+    currency: "USD",
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: "acc-2",
+    name: "Rainy Day Savings",
+    type: "savings",
+    balance: 12940.54,
+    currency: "USD",
+    updatedAt: new Date().toISOString(),
+  },
+];
+
+const wait = async (duration = 250) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, duration);
+  });
+
+export async function listAccounts() {
+  await wait();
+  return [...accounts];
+}
+
+export async function getAccountById(id: string) {
+  await wait();
+  return accounts.find((account) => account.id === id) ?? null;
+}
+
+export async function createAccount(input: Omit<AccountRecord, "id" | "updatedAt">) {
+  await wait();
+
+  const account: AccountRecord = {
+    ...input,
+    id: `acc-${Date.now()}`,
+    updatedAt: new Date().toISOString(),
+  };
+
+  accounts = [account, ...accounts];
+  return account;
+}
+
+export async function updateAccount(id: string, updates: Partial<Omit<AccountRecord, "id">>) {
+  await wait();
+
+  const current = accounts.find((account) => account.id === id);
+  if (!current) {
+    throw new Error("Account not found");
+  }
+
+  const updated: AccountRecord = {
+    ...current,
+    ...updates,
+    updatedAt: new Date().toISOString(),
+  };
+
+  accounts = accounts.map((account) => (account.id === id ? updated : account));
+  return updated;
+}
+
+export async function deleteAccount(id: string) {
+  await wait();
+
+  const existing = accounts.find((account) => account.id === id);
+  if (!existing) {
+    throw new Error("Account not found");
+  }
+
+  accounts = accounts.filter((account) => account.id !== id);
+  return existing;
+}

--- a/apps/native/app/(tabs)/finance/accounts/index.tsx
+++ b/apps/native/app/(tabs)/finance/accounts/index.tsx
@@ -1,10 +1,87 @@
-import { View, Text } from "@/components";
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
+import { StyleSheet, Pressable } from "react-native";
+import { router } from "expo-router";
 
-export default function Index() {
+import { Alert, Button, Text, View } from "@/components";
+import { UI_PRESETS } from "@/lib/constants";
+import { listAccounts, type AccountRecord } from "./data";
+
+export default function AccountsIndex() {
+  const [accounts, setAccounts] = useState<AccountRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadAccounts = useCallback(async () => {
+    setIsLoading(true);
+    const records = await listAccounts();
+    setAccounts(records);
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void loadAccounts();
+  }, [loadAccounts]);
+
   return (
-    <View>
-      <Text>first</Text>
+    <View style={styles.screen}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Accounts</Text>
+        <Button title="Create" onPress={() => router.push("/(tabs)/finance/accounts/create")} />
+      </View>
+
+      {isLoading ? <Text>Loading accounts…</Text> : null}
+
+      {!isLoading && accounts.length === 0 ? (
+        <Alert
+          title="No accounts yet"
+          message="Create your first account to start tracking balances and cash flow."
+          variant="info"
+        />
+      ) : null}
+
+      {accounts.map((account) => (
+        <Pressable
+          key={account.id}
+          style={styles.item}
+          onPress={() => router.push(`/(tabs)/finance/accounts/${account.id}/update`)}
+        >
+          <Text style={styles.itemTitle}>{account.name}</Text>
+          <Text style={styles.meta}>
+            {account.type.toUpperCase()} · {account.currency} {account.balance.toFixed(2)}
+          </Text>
+        </Pressable>
+      ))}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    padding: UI_PRESETS.spacing.screen,
+    gap: UI_PRESETS.spacing.lg,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  title: {
+    fontFamily: "Geist",
+    fontSize: 22,
+  },
+  item: {
+    borderWidth: 1,
+    borderColor: "#A6ADC8",
+    borderRadius: UI_PRESETS.radius.lg,
+    padding: UI_PRESETS.spacing.xl,
+    gap: UI_PRESETS.spacing.xs,
+  },
+  itemTitle: {
+    fontFamily: "Geist",
+    fontSize: 16,
+  },
+  meta: {
+    fontFamily: "Figtree",
+    opacity: UI_PRESETS.opacity.muted,
+  },
+});


### PR DESCRIPTION
### Motivation
- Provide route-driven account loading for `accounts/[id]` so `update`/`delete` screens resolve the route `id` and handle missing or deleted records gracefully.
- Improve destructive flows by showing contextual metadata and requiring explicit confirmation before irreversible actions.
- Surface clear success/error feedback and prevent duplicate submissions using toasts, route transitions, and tokenized disabled opacity rules from constants.

### Description
- Add a route-scoped provider `RouteAccountProvider` and hook `useRouteAccount` under `accounts/[id]` to resolve the `id` param and expose `account`, `isLoading`, `error`, and `refreshAccount` (`apps/.../[id]/route-context.tsx`, `apps/.../[id]/_layout.tsx`).
- Add a local async data module `accounts/data.ts` that implements `listAccounts`, `getAccountById`, `createAccount`, `updateAccount`, and `deleteAccount` with sample records and `updatedAt` metadata.
- Rework `index`, `create`, `update`, and `delete` screens to use `expo-router` for navigation, `sonner-native` `toast` for success/failure feedback, `Dialog`/`Alert` for delete confirmation and contextual warnings, and `UI_PRESETS` disabled opacity for guarded UI states.
- Implement loading guards and tokenized `disabled`/`loading` states to prevent repeated submissions and ensure controls are disabled while mutations are pending.

### Testing
- Ran the TypeScript check `bunx tsc -p apps/native/tsconfig.json --noEmit`, which failed due to the environment's missing Expo tsconfig and dependency type setup that pre-existed the change and is unrelated to the new UX code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a536563c708321bba433dfb5e4281c)