### PR TITLE
Add AI onboarding backend foundation

### DIFF
--- a/packages/backend/convex/aiOnboarding.ts
+++ b/packages/backend/convex/aiOnboarding.ts
@@ -1,0 +1,675 @@
+import { ConvexError, v } from "convex/values";
+
+import type { Doc, Id } from "./_generated/dataModel";
+import { mutation, query } from "./_generated/server";
+import {
+  AI_ONBOARDING_QUESTIONS,
+  HARD_CODED_ACTIVITY_TEMPLATES,
+  average,
+  buildSystemPrompt,
+  getAssignmentItemId,
+  getCommitmentTargetCount,
+  getDecayedWeight,
+  getEndOfDayTimestamp,
+  getPhaseForDay,
+  getTier,
+  matchesProfile,
+} from "./lib/aiOnboarding";
+import { requireUserId } from "./lib/identity";
+import {
+  aiOnboardingActivityActionValidator,
+  aiOnboardingCategoryValidator,
+  aiOnboardingFeedbackVerdictValidator,
+  aiOnboardingPhaseValidator,
+  aiOnboardingProfileAnswersValidator,
+} from "./schema/aiOnboarding";
+
+export const getQuestions = query({
+  args: {},
+  returns: v.array(
+    v.object({
+      key: v.string(),
+      title: v.string(),
+      hint: v.string(),
+      options: v.array(
+        v.object({
+          label: v.string(),
+          sub: v.optional(v.string()),
+          value: v.string(),
+        }),
+      ),
+    }),
+  ),
+  handler: async () => {
+    return AI_ONBOARDING_QUESTIONS.map((question) => ({
+      key: question.key,
+      title: question.title,
+      hint: question.hint,
+      options: question.options.map((option) => ({
+        label: option.label,
+        sub: "sub" in option ? option.sub : undefined,
+        value: option.value,
+      })),
+    }));
+  },
+});
+
+export const getProfile = query({
+  args: {},
+  handler: async (ctx: any) => {
+    const userId = await requireUserId(ctx);
+    return await ctx.db
+      .query("aiOnboardingProfiles")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .first();
+  },
+});
+
+export const seedHardcodedActivityTemplates = mutation({
+  args: {},
+  returns: v.object({ inserted: v.number(), updated: v.number() }),
+  handler: async (ctx: any) => {
+    const now = Date.now();
+    let inserted = 0;
+    let updated = 0;
+
+    for (const template of HARD_CODED_ACTIVITY_TEMPLATES) {
+      const existing = await ctx.db
+        .query("aiOnboardingActivityTemplates")
+        .withIndex("by_slug", (q) => q.eq("slug", template.slug))
+        .first();
+
+      const patch = {
+        title: template.title,
+        category: template.category,
+        difficulty: template.difficulty,
+        source: template.source,
+        durationMinutes: template.durationMinutes,
+        instructions: template.instructions,
+        signalMap: template.signalMap,
+        isHardcoded: template.isHardcoded,
+        goalTargets: [...template.goalTargets],
+        energyTargets: [...template.energyTargets],
+        minDayNumber: template.minDayNumber,
+        updatedAt: now,
+      };
+
+      if (existing) {
+        await ctx.db.patch(existing._id, patch);
+        updated += 1;
+        continue;
+      }
+
+      await ctx.db.insert("aiOnboardingActivityTemplates", {
+        slug: template.slug,
+        ...patch,
+        createdAt: now,
+      });
+      inserted += 1;
+    }
+
+    return { inserted, updated };
+  },
+});
+
+export const completeAiOnboarding = mutation({
+  args: {
+    answers: aiOnboardingProfileAnswersValidator,
+    timezone: v.optional(v.string()),
+  },
+  handler: async (ctx: any, args: any) => {
+    const userId = await requireUserId(ctx);
+    const now = Date.now();
+    const timezone = args.timezone?.trim() || "UTC";
+    const existing = await ctx.db
+      .query("aiOnboardingProfiles")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .first();
+
+    const dayNumber = existing?.dayNumber ?? 1;
+    const patch = {
+      primaryGoal: args.answers.primaryGoal,
+      energyPattern: args.answers.energyPattern,
+      biggestBlocker: args.answers.biggestBlocker,
+      preferredStyle: args.answers.preferredStyle,
+      commitmentLevel: args.answers.commitmentLevel,
+      timezone,
+      dayNumber,
+      seedAnswers: args.answers,
+      updatedAt: now,
+    };
+
+    let profileId: Id<"aiOnboardingProfiles">;
+    if (existing) {
+      await ctx.db.patch(existing._id, patch);
+      profileId = existing._id;
+    } else {
+      profileId = await ctx.db.insert("aiOnboardingProfiles", {
+        userId,
+        ...patch,
+        createdAt: now,
+      });
+    }
+
+    await ensureHardcodedTemplates(ctx);
+    const assigned = await assignDayActivities(ctx, {
+      userId,
+      dayNumber,
+      phase: getPhaseForDay(dayNumber),
+      now,
+    });
+
+    return {
+      ok: true,
+      profileId,
+      dayNumber,
+      assignedCount: assigned.length,
+    };
+  },
+});
+
+export const advanceDay = mutation({
+  args: {
+    dayNumber: v.optional(v.number()),
+  },
+  returns: v.object({ dayNumber: v.number(), assignedCount: v.number() }),
+  handler: async (ctx: any, args: any) => {
+    const userId = await requireUserId(ctx);
+    const profile = await requireProfile(ctx, userId);
+    const nextDayNumber = Math.max(args.dayNumber ?? profile.dayNumber + 1, 1);
+    const now = Date.now();
+
+    await ctx.db.patch(profile._id, {
+      dayNumber: nextDayNumber,
+      updatedAt: now,
+    });
+
+    await ensureHardcodedTemplates(ctx);
+    const assignments = await assignDayActivities(ctx, {
+      userId,
+      dayNumber: nextDayNumber,
+      phase: getPhaseForDay(nextDayNumber),
+      now,
+    });
+
+    return {
+      dayNumber: nextDayNumber,
+      assignedCount: assignments.length,
+    };
+  },
+});
+
+export const getAssignmentsForDay = query({
+  args: {
+    dayNumber: v.optional(v.number()),
+  },
+  handler: async (ctx: any, args: any) => {
+    const userId = await requireUserId(ctx);
+    const profile = await ctx.db
+      .query("aiOnboardingProfiles")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .first();
+
+    if (!profile) {
+      return [];
+    }
+
+    const dayNumber = args.dayNumber ?? profile.dayNumber;
+    const assignments = await ctx.db
+      .query("aiOnboardingActivityAssignments")
+      .withIndex("by_userId_day", (q) => q.eq("userId", userId).eq("dayNumber", dayNumber))
+      .collect();
+
+    const templates = await Promise.all(
+      assignments.map((assignment) => ctx.db.get(assignment.templateId)),
+    );
+
+    return assignments.map((assignment, index) => ({
+      ...assignment,
+      template: templates[index],
+    }));
+  },
+});
+
+export const createSuggestion = mutation({
+  args: {
+    category: aiOnboardingCategoryValidator,
+    content: v.string(),
+    reasoning: v.optional(v.string()),
+    confidenceAtTime: v.number(),
+    phase: aiOnboardingPhaseValidator,
+  },
+  handler: async (ctx: any, args: any) => {
+    const userId = await requireUserId(ctx);
+    return await ctx.db.insert("aiOnboardingSuggestions", {
+      userId,
+      category: args.category,
+      content: args.content.trim(),
+      reasoning: args.reasoning?.trim(),
+      confidenceAtTime: Math.round(Math.max(0, Math.min(100, args.confidenceAtTime))),
+      phase: args.phase,
+      shownAt: Date.now(),
+    });
+  },
+});
+
+export const recordSuggestionFeedback = mutation({
+  args: {
+    suggestionId: v.id("aiOnboardingSuggestions"),
+    verdict: aiOnboardingFeedbackVerdictValidator,
+    reason: v.optional(v.string()),
+  },
+  returns: v.object({ ok: v.boolean() }),
+  handler: async (ctx: any, args: any) => {
+    const userId = await requireUserId(ctx);
+    const suggestion = await ctx.db.get(args.suggestionId);
+
+    if (!suggestion || suggestion.userId !== userId) {
+      throw new ConvexError("Suggestion not found");
+    }
+
+    await ctx.db.insert("aiOnboardingFeedback", {
+      suggestionId: args.suggestionId,
+      userId,
+      verdict: args.verdict,
+      reason: args.reason?.trim(),
+      createdAt: Date.now(),
+    });
+
+    const deltaByVerdict: Record<Doc<"aiOnboardingFeedback">["verdict"], number> = {
+      accepted: 12,
+      dismissed: -10,
+      snoozed: -2,
+    };
+
+    await updateConfidenceScore(ctx, {
+      userId,
+      category: suggestion.category,
+      delta: deltaByVerdict[args.verdict],
+      verdict: args.verdict,
+    });
+
+    return { ok: true };
+  },
+});
+
+export const recordActivityEvent = mutation({
+  args: {
+    assignmentId: v.id("aiOnboardingActivityAssignments"),
+    action: aiOnboardingActivityActionValidator,
+    elapsedMs: v.optional(v.number()),
+    metadata: v.optional(v.any()),
+  },
+  returns: v.object({ ok: v.boolean() }),
+  handler: async (ctx: any, args: any) => {
+    const userId = await requireUserId(ctx);
+    const assignment = await ctx.db.get(args.assignmentId);
+
+    if (!assignment || assignment.userId !== userId) {
+      throw new ConvexError("Assignment not found");
+    }
+
+    const template = await ctx.db.get(assignment.templateId);
+    if (!template) {
+      throw new ConvexError("Activity template not found");
+    }
+
+    const signalDef = template.signalMap[args.action];
+    const now = Date.now();
+
+    await ctx.db.insert("aiOnboardingActivityEvents", {
+      assignmentId: args.assignmentId,
+      userId,
+      action: args.action,
+      elapsedMs: args.elapsedMs ?? 0,
+      metadata: args.metadata,
+      createdAt: now,
+    });
+
+    if (signalDef) {
+      await ctx.db.insert("aiOnboardingSignals", {
+        userId,
+        category: signalDef.category,
+        action: signalDef.action,
+        itemId: getAssignmentItemId(args.assignmentId),
+        durationMs: args.elapsedMs,
+        metadata: args.metadata,
+        createdAt: now,
+      });
+
+      await updateConfidenceScore(ctx, {
+        userId,
+        category: signalDef.category,
+        delta: signalDef.weight,
+        verdict:
+          args.action === "completed"
+            ? "accepted"
+            : args.action === "skipped"
+              ? "dismissed"
+              : null,
+      });
+    }
+
+    if (args.action === "completed" || args.action === "skipped") {
+      await ctx.db.patch(assignment._id, {
+        status: args.action,
+        completedAt: args.action === "completed" ? now : assignment.completedAt,
+        skippedAt: args.action === "skipped" ? now : assignment.skippedAt,
+      });
+    }
+
+    return { ok: true };
+  },
+});
+
+export const recordReflection = mutation({
+  args: {
+    assignmentId: v.id("aiOnboardingActivityAssignments"),
+    difficultyRating: v.optional(v.number()),
+    usefulnessRating: v.optional(v.number()),
+    note: v.optional(v.string()),
+  },
+  returns: v.object({ ok: v.boolean() }),
+  handler: async (ctx: any, args: any) => {
+    const userId = await requireUserId(ctx);
+    const assignment = await ctx.db.get(args.assignmentId);
+
+    if (!assignment || assignment.userId !== userId) {
+      throw new ConvexError("Assignment not found");
+    }
+
+    const now = Date.now();
+    await ctx.db.insert("aiOnboardingActivityReflections", {
+      assignmentId: args.assignmentId,
+      userId,
+      difficultyRating: args.difficultyRating,
+      usefulnessRating: args.usefulnessRating,
+      note: args.note?.trim(),
+      createdAt: now,
+    });
+
+    await ctx.db.insert("aiOnboardingSignals", {
+      userId,
+      category: "habits",
+      action: "reflected",
+      itemId: getAssignmentItemId(args.assignmentId),
+      metadata: {
+        difficulty: args.difficultyRating,
+        usefulness: args.usefulnessRating,
+      },
+      createdAt: now,
+    });
+
+    await updateConfidenceScore(ctx, {
+      userId,
+      category: "habits",
+      delta: 10,
+      verdict: "accepted",
+    });
+
+    return { ok: true };
+  },
+});
+
+export const getDailyAIContext = query({
+  args: {},
+  handler: async (ctx: any) => {
+    const userId = await requireUserId(ctx);
+    const [profile, scores, recentSignals, recentAssignments] = await Promise.all([
+      ctx.db
+        .query("aiOnboardingProfiles")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .first(),
+      ctx.db
+        .query("aiOnboardingConfidenceScores")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .collect(),
+      ctx.db
+        .query("aiOnboardingSignals")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .order("desc")
+        .take(30),
+      ctx.db
+        .query("aiOnboardingActivityAssignments")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .order("desc")
+        .take(15),
+    ]);
+
+    if (!profile) {
+      return null;
+    }
+
+    const [reflections, templates] = await Promise.all([
+      Promise.all(
+        recentAssignments.map((assignment) =>
+          ctx.db
+            .query("aiOnboardingActivityReflections")
+            .withIndex("by_assignmentId", (q) => q.eq("assignmentId", assignment._id))
+            .first(),
+        ),
+      ),
+      Promise.all(recentAssignments.map((assignment) => ctx.db.get(assignment.templateId))),
+    ]);
+
+    const categories: Doc<"aiOnboardingSignals">["category"][] = [
+      "focus",
+      "sleep",
+      "exercise",
+      "habits",
+      "tasks",
+    ];
+
+    const signalSummary = Object.fromEntries(
+      categories.map((category) => {
+        const categorySignals = recentSignals.filter((signal) => signal.category === category);
+        const score = scores.find((entry) => entry.category === category);
+        return [
+          category,
+          {
+            score: score?.score ?? 0,
+            signalCount: score?.signalCount ?? 0,
+            completions: categorySignals.filter((signal) => signal.action === "completed").length,
+            skips: categorySignals.filter((signal) => signal.action === "skipped").length,
+            avgDuration: average(categorySignals.map((signal) => signal.durationMs ?? 0)),
+            tier: getTier(score?.score ?? 0).range,
+          },
+        ];
+      }),
+    );
+
+    return {
+      profile,
+      signalSummary,
+      rawSignals: recentSignals,
+      assignments: recentAssignments.map((assignment, index) => ({
+        ...assignment,
+        template: templates[index],
+        reflection: reflections[index],
+      })),
+      readyForBoldSuggestions: scores.some((entry) => entry.score >= 80),
+      overallEngagement: average(scores.map((entry) => entry.score)),
+      promptPreviewByCategory: Object.fromEntries(
+        categories.map((category) => [
+          category,
+          buildSystemPrompt({
+            profile,
+            scores: scores.map((entry) => ({ category: entry.category, score: entry.score })),
+            recentSignals: recentSignals.map((signal) => ({
+              category: signal.category,
+              action: signal.action,
+              itemId: signal.itemId,
+              durationMs: signal.durationMs,
+            })),
+            category,
+          }),
+        ]),
+      ),
+    };
+  },
+});
+
+async function ensureHardcodedTemplates(ctx: Parameters<typeof seedHardcodedActivityTemplates.handler>[0]) {
+  const now = Date.now();
+
+  for (const template of HARD_CODED_ACTIVITY_TEMPLATES) {
+    const existing = await ctx.db
+      .query("aiOnboardingActivityTemplates")
+      .withIndex("by_slug", (q) => q.eq("slug", template.slug))
+      .first();
+
+    if (existing) {
+      continue;
+    }
+
+    await ctx.db.insert("aiOnboardingActivityTemplates", {
+      slug: template.slug,
+      title: template.title,
+      category: template.category,
+      difficulty: template.difficulty,
+      source: template.source,
+      durationMinutes: template.durationMinutes,
+      instructions: template.instructions,
+      signalMap: template.signalMap,
+      isHardcoded: template.isHardcoded,
+      goalTargets: [...template.goalTargets],
+      energyTargets: [...template.energyTargets],
+      minDayNumber: template.minDayNumber,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+}
+
+async function assignDayActivities(
+  ctx: Parameters<typeof completeAiOnboarding.handler>[0],
+  args: {
+    userId: string;
+    dayNumber: number;
+    phase: Doc<"aiOnboardingActivityAssignments">["phase"];
+    now: number;
+  },
+) {
+  const profile = await requireProfile(ctx, args.userId);
+  const existing = await ctx.db
+    .query("aiOnboardingActivityAssignments")
+    .withIndex("by_userId_day", (q) => q.eq("userId", args.userId).eq("dayNumber", args.dayNumber))
+    .collect();
+
+  if (existing.length > 0) {
+    return existing;
+  }
+
+  const templates = await ctx.db
+    .query("aiOnboardingActivityTemplates")
+    .withIndex("by_isHardcoded", (q) => q.eq("isHardcoded", true))
+    .collect();
+
+  const targetCount = getCommitmentTargetCount(profile.commitmentLevel);
+  const filtered = templates
+    .filter((template) => matchesProfile(template, profile))
+    .sort((left, right) => left.durationMinutes - right.durationMinutes)
+    .slice(0, targetCount);
+
+  const assignmentIds = await Promise.all(
+    filtered.map((template) =>
+      ctx.db.insert("aiOnboardingActivityAssignments", {
+        userId: args.userId,
+        templateId: template._id,
+        dayNumber: args.dayNumber,
+        status: "pending",
+        phase: args.phase,
+        assignedBy: args.phase === "seed" ? "system" : "ai",
+        assignedAt: args.now,
+        dueAt: getEndOfDayTimestamp(args.now),
+      }),
+    ),
+  );
+
+  return await Promise.all(
+    assignmentIds.map(async (assignmentId) => {
+      const assignment = await ctx.db.get(assignmentId);
+      if (!assignment) {
+        throw new ConvexError("Failed to read assigned activity");
+      }
+      return assignment;
+    }),
+  );
+}
+
+async function requireProfile(
+  ctx: Parameters<typeof completeAiOnboarding.handler>[0],
+  userId: string,
+) {
+  const profile = await ctx.db
+    .query("aiOnboardingProfiles")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .first();
+
+  if (!profile) {
+    throw new ConvexError("AI onboarding profile not found");
+  }
+
+  return profile;
+}
+
+async function updateConfidenceScore(
+  ctx: Parameters<typeof completeAiOnboarding.handler>[0],
+  args: {
+    userId: string;
+    category: Doc<"aiOnboardingConfidenceScores">["category"];
+    delta: number;
+    verdict: Doc<"aiOnboardingFeedback">["verdict"] | null;
+  },
+) {
+  const existing = await ctx.db
+    .query("aiOnboardingConfidenceScores")
+    .withIndex("by_userId_category", (q) => q.eq("userId", args.userId).eq("category", args.category))
+    .first();
+
+  const profileSignals = await ctx.db
+    .query("aiOnboardingSignals")
+    .withIndex("by_userId_category", (q) => q.eq("userId", args.userId).eq("category", args.category))
+    .collect();
+
+  const weightedDelta = Math.round(
+    profileSignals.reduce((sum, signal) => {
+      const actionWeight = signal.action === "skipped" ? -5 : signal.action === "completed" ? 20 : 5;
+      return sum + getDecayedWeight(signal.createdAt, actionWeight);
+    }, 0) + args.delta,
+  );
+
+  const base = existing ?? {
+    score: 0,
+    signalCount: 0,
+    acceptCount: 0,
+    dismissCount: 0,
+  };
+
+  const nextSignalCount = base.signalCount + 1;
+  const nextAcceptCount =
+    args.verdict === "accepted" ? base.acceptCount + 1 : base.acceptCount;
+  const nextDismissCount =
+    args.verdict === "dismissed" ? base.dismissCount + 1 : base.dismissCount;
+  const acceptRatio = nextSignalCount > 0 ? nextAcceptCount / nextSignalCount : 0;
+  const rawScore = weightedDelta + acceptRatio * 5;
+  const score = Math.round(Math.max(0, Math.min(100, rawScore)));
+  const payload = {
+    score,
+    signalCount: nextSignalCount,
+    acceptCount: nextAcceptCount,
+    dismissCount: nextDismissCount,
+    updatedAt: Date.now(),
+  };
+
+  if (existing) {
+    await ctx.db.patch(existing._id, payload);
+    return;
+  }
+
+  await ctx.db.insert("aiOnboardingConfidenceScores", {
+    userId: args.userId,
+    category: args.category,
+    ...payload,
+  });
+}

--- a/packages/backend/convex/lib/aiOnboarding.ts
+++ b/packages/backend/convex/lib/aiOnboarding.ts
@@ -1,0 +1,424 @@
+import type { Doc, Id } from "../_generated/dataModel";
+
+type AiOnboardingQuestionOption = {
+  label: string;
+  value: string;
+  sub?: string;
+};
+
+type AiOnboardingQuestion = {
+  key: string;
+  title: string;
+  hint: string;
+  options: AiOnboardingQuestionOption[];
+};
+
+type HardcodedActivityTemplate = {
+  slug: string;
+  title: string;
+  category: Doc<"aiOnboardingActivityTemplates">["category"];
+  difficulty: Doc<"aiOnboardingActivityTemplates">["difficulty"];
+  source: Doc<"aiOnboardingActivityTemplates">["source"];
+  durationMinutes: number;
+  instructions: string;
+  signalMap: Doc<"aiOnboardingActivityTemplates">["signalMap"];
+  isHardcoded: boolean;
+  goalTargets: Doc<"aiOnboardingActivityTemplates">["goalTargets"];
+  energyTargets: Doc<"aiOnboardingActivityTemplates">["energyTargets"];
+  minDayNumber?: number;
+};
+
+
+export const AI_ONBOARDING_QUESTIONS: readonly AiOnboardingQuestion[] = [
+  {
+    key: "primaryGoal",
+    title: "What brings you here?",
+    hint: "Pick the one that feels most urgent right now.",
+    options: [
+      {
+        label: "Get more done each day",
+        sub: "Focus, tasks, deep work",
+        value: "productivity",
+      },
+      {
+        label: "Feel less overwhelmed",
+        sub: "Stress, clarity, calm",
+        value: "wellbeing",
+      },
+      {
+        label: "Build better habits",
+        sub: "Consistency, routines",
+        value: "habits",
+      },
+      {
+        label: "Improve my health",
+        sub: "Sleep, movement, energy",
+        value: "health",
+      },
+    ],
+  },
+  {
+    key: "energyPattern",
+    title: "When do you feel sharpest?",
+    hint: "This shapes when we suggest your hardest tasks.",
+    options: [
+      { label: "Morning — I peak before noon", value: "morning" },
+      { label: "Afternoon — I warm up slowly", value: "afternoon" },
+      { label: "Evening — I come alive late", value: "evening" },
+      { label: "It varies a lot", value: "variable" },
+    ],
+  },
+  {
+    key: "biggestBlocker",
+    title: "What usually gets in the way?",
+    hint: "Be honest — this is just for you.",
+    options: [
+      {
+        label: "I start things but don't finish",
+        value: "follow_through",
+      },
+      { label: "I get distracted easily", value: "distraction" },
+      { label: "I don't know where to start", value: "overwhelm" },
+      { label: "I run out of energy", value: "energy" },
+    ],
+  },
+  {
+    key: "preferredStyle",
+    title: "How do you want to be coached?",
+    hint: "This changes how we talk to you as you progress.",
+    options: [
+      {
+        label: "Gentle nudges",
+        sub: "Low pressure, optional",
+        value: "gentle",
+      },
+      {
+        label: "Clear and direct",
+        sub: "Tell me what to do",
+        value: "direct",
+      },
+      {
+        label: "Structured plans",
+        sub: "Steps, schedules, systems",
+        value: "structured",
+      },
+    ],
+  },
+  {
+    key: "commitmentLevel",
+    title: "How much time can you give this?",
+    hint: "Honest beats ambitious — we'll adapt either way.",
+    options: [
+      { label: "5–10 min/day", value: "light" },
+      { label: "15–20 min/day", value: "moderate" },
+      { label: "30+ min/day", value: "committed" },
+    ],
+  },
+] as const;
+
+const TIERS = {
+  observe: {
+    range: [0, 30] as const,
+    promptFragment: `
+Confidence level: LOW (score: {score})
+You have very limited data about this user.
+Do not make personal suggestions yet.
+Instead, offer 1 gentle, universally applicable habit
+framed as a question: "Many people find X helpful —
+would this be relevant to you?"
+Never reference their past behaviour.
+`.trim(),
+  },
+  suggest: {
+    range: [31, 55] as const,
+    promptFragment: `
+Confidence level: MODERATE (score: {score})
+You have some behavioural signals. Make 1–2 soft,
+tentative suggestions tied to observed patterns.
+Frame as: "I noticed you tend to... so you might try..."
+Always offer an opt-out: "Does this feel relevant?"
+Avoid absolute language like "you should" or "you must".
+`.trim(),
+  },
+  recommend: {
+    range: [56, 79] as const,
+    promptFragment: `
+Confidence level: HIGH (score: {score})
+You have consistent signal across multiple days.
+Make clear, direct recommendations grounded in
+specific observations. Explain your reasoning briefly:
+"Based on how you've been engaging with X, I think Y
+would work well for you because Z."
+You can suggest 2–3 changes at once if they're related.
+`.trim(),
+  },
+  act: {
+    range: [80, 100] as const,
+    promptFragment: `
+Confidence level: VERY HIGH (score: {score})
+You know this user's patterns well. Be proactive and
+assertive. Suggest bold changes — restructuring
+routines, dropping habits that aren't working,
+introducing new challenges. Reference specific patterns:
+"You've consistently done X — it's time to level up to Y."
+Propose, don't just suggest. The user trusts you.
+`.trim(),
+  },
+} as const;
+
+export const HARD_CODED_ACTIVITY_TEMPLATES: readonly HardcodedActivityTemplate[] = [
+  {
+    slug: "morning-check-in",
+    title: "Morning check-in",
+    category: "habits",
+    difficulty: "easy",
+    source: "hardcoded",
+    durationMinutes: 2,
+    instructions: "Take a quick pulse check before the day starts and name what matters most.",
+    signalMap: {
+      viewed: { category: "habits", action: "viewed", weight: 1 },
+      started: { category: "habits", action: "started", weight: 5 },
+      completed: { category: "habits", action: "completed", weight: 15 },
+      skipped: { category: "habits", action: "skipped", weight: -5 },
+      reflected: { category: "habits", action: "reflected", weight: 10 },
+    },
+    isHardcoded: true,
+    goalTargets: ["productivity", "wellbeing", "habits", "health"],
+    energyTargets: ["morning", "afternoon", "evening", "variable"],
+  },
+  {
+    slug: "write-three-priorities",
+    title: "Write 3 priorities",
+    category: "focus",
+    difficulty: "easy",
+    source: "hardcoded",
+    durationMinutes: 5,
+    instructions: "Choose the three most important outcomes for today before you open every app.",
+    signalMap: {
+      viewed: { category: "focus", action: "viewed", weight: 1 },
+      started: { category: "focus", action: "started", weight: 5 },
+      completed: { category: "focus", action: "completed", weight: 20 },
+      skipped: { category: "focus", action: "skipped", weight: -5 },
+      reflected: { category: "habits", action: "reflected", weight: 10 },
+    },
+    isHardcoded: true,
+    goalTargets: ["productivity", "habits"],
+    energyTargets: ["morning", "afternoon", "evening", "variable"],
+  },
+  {
+    slug: "evening-wind-down",
+    title: "Evening wind-down",
+    category: "sleep",
+    difficulty: "easy",
+    source: "hardcoded",
+    durationMinutes: 5,
+    instructions: "Close the day with a short reset so tomorrow feels lighter.",
+    signalMap: {
+      viewed: { category: "sleep", action: "viewed", weight: 1 },
+      started: { category: "sleep", action: "started", weight: 5 },
+      completed: { category: "sleep", action: "completed", weight: 15 },
+      skipped: { category: "sleep", action: "skipped", weight: -5 },
+      reflected: { category: "habits", action: "reflected", weight: 10 },
+    },
+    isHardcoded: true,
+    goalTargets: ["productivity", "wellbeing", "habits", "health"],
+    energyTargets: ["morning", "afternoon", "evening", "variable"],
+  },
+  {
+    slug: "focus-block-25",
+    title: "Focus block (25 min)",
+    category: "focus",
+    difficulty: "medium",
+    source: "hardcoded",
+    durationMinutes: 25,
+    instructions: "Protect a 25 minute block for one meaningful task and ignore everything else.",
+    signalMap: {
+      viewed: { category: "focus", action: "viewed", weight: 1 },
+      started: { category: "focus", action: "started", weight: 5 },
+      completed: { category: "focus", action: "completed", weight: 20 },
+      skipped: { category: "focus", action: "skipped", weight: -5 },
+      reflected: { category: "habits", action: "reflected", weight: 10 },
+    },
+    isHardcoded: true,
+    goalTargets: ["productivity", "habits"],
+    energyTargets: ["morning", "afternoon"],
+  },
+  {
+    slug: "reflect-on-blocker",
+    title: "Reflect on blocker",
+    category: "habits",
+    difficulty: "easy",
+    source: "hardcoded",
+    durationMinutes: 5,
+    instructions: "Name the friction point that showed up today and write one way to make it easier tomorrow.",
+    signalMap: {
+      viewed: { category: "habits", action: "viewed", weight: 1 },
+      started: { category: "habits", action: "started", weight: 5 },
+      completed: { category: "habits", action: "completed", weight: 15 },
+      skipped: { category: "habits", action: "skipped", weight: -5 },
+      reflected: { category: "habits", action: "reflected", weight: 10 },
+    },
+    isHardcoded: true,
+    goalTargets: ["productivity", "wellbeing", "habits", "health"],
+    energyTargets: ["morning", "afternoon", "evening", "variable"],
+    minDayNumber: 2,
+  },
+  {
+    slug: "walk-after-lunch",
+    title: "Walk after lunch",
+    category: "exercise",
+    difficulty: "easy",
+    source: "hardcoded",
+    durationMinutes: 15,
+    instructions: "Take a short walk after lunch to reset your energy and attention.",
+    signalMap: {
+      viewed: { category: "exercise", action: "viewed", weight: 1 },
+      started: { category: "exercise", action: "started", weight: 5 },
+      completed: { category: "exercise", action: "completed", weight: 20 },
+      skipped: { category: "exercise", action: "skipped", weight: -5 },
+      reflected: { category: "habits", action: "reflected", weight: 10 },
+    },
+    isHardcoded: true,
+    goalTargets: ["health", "wellbeing"],
+    energyTargets: ["morning", "afternoon", "evening", "variable"],
+  },
+] as const;
+
+export function getTier(score: number) {
+  if (score >= 80) {
+    return TIERS.act;
+  }
+  if (score >= 56) {
+    return TIERS.recommend;
+  }
+  if (score >= 31) {
+    return TIERS.suggest;
+  }
+  return TIERS.observe;
+}
+
+export function getPhaseForDay(dayNumber: number) {
+  if (dayNumber <= 2) {
+    return "seed" as const;
+  }
+  if (dayNumber <= 5) {
+    return "learn" as const;
+  }
+  return "act" as const;
+}
+
+export function getCommitmentTargetCount(commitmentLevel: string) {
+  const commitmentToCount: Record<string, number> = {
+    light: 2,
+    moderate: 3,
+    committed: 4,
+  };
+  return commitmentToCount[commitmentLevel] ?? 3;
+}
+
+export function matchesProfile(
+  template: Pick<
+    Doc<"aiOnboardingActivityTemplates">,
+    "category" | "goalTargets" | "energyTargets" | "minDayNumber"
+  >,
+  profile: Pick<
+    Doc<"aiOnboardingProfiles">,
+    "primaryGoal" | "energyPattern" | "dayNumber"
+  >,
+) {
+  if (template.minDayNumber && profile.dayNumber < template.minDayNumber) {
+    return false;
+  }
+
+  if (!template.goalTargets.includes(profile.primaryGoal)) {
+    return false;
+  }
+
+  if (!template.energyTargets.includes(profile.energyPattern)) {
+    return false;
+  }
+
+  if (template.category === "habits" || template.category === "sleep") {
+    return true;
+  }
+
+  const goalMap: Record<string, string[]> = {
+    productivity: ["focus", "tasks", "habits"],
+    health: ["exercise", "sleep", "habits"],
+    wellbeing: ["exercise", "habits", "sleep"],
+    habits: ["habits", "focus", "sleep"],
+  };
+
+  return (goalMap[profile.primaryGoal] ?? []).includes(template.category);
+}
+
+export function getEndOfDayTimestamp(now = Date.now()) {
+  const date = new Date(now);
+  date.setUTCHours(23, 59, 59, 999);
+  return date.getTime();
+}
+
+export function average(numbers: number[]) {
+  if (numbers.length === 0) {
+    return 0;
+  }
+  return Math.round(numbers.reduce((sum, value) => sum + value, 0) / numbers.length);
+}
+
+export function getDecayedWeight(createdAt: number, baseWeight: number, now = Date.now()) {
+  const ageDays = (now - createdAt) / (1000 * 60 * 60 * 24);
+  const decay = ageDays > 3 ? Math.pow(0.85, ageDays - 3) : 1;
+  return baseWeight * decay;
+}
+
+export function buildSystemPrompt(args: {
+  profile: Pick<
+    Doc<"aiOnboardingProfiles">,
+    | "primaryGoal"
+    | "energyPattern"
+    | "biggestBlocker"
+    | "preferredStyle"
+    | "commitmentLevel"
+    | "dayNumber"
+  >;
+  scores: Array<Pick<Doc<"aiOnboardingConfidenceScores">, "category" | "score">>;
+  recentSignals: Array<
+    Pick<Doc<"aiOnboardingSignals">, "category" | "action" | "itemId" | "durationMs">
+  >;
+  category: Doc<"aiOnboardingSignals">["category"];
+}) {
+  const score = args.scores.find((entry) => entry.category === args.category)?.score ?? 0;
+  const tier = getTier(score);
+  const signals = args.recentSignals.filter((entry) => entry.category === args.category);
+
+  return `
+You are a personal coach helping the user achieve: ${args.profile.primaryGoal}.
+
+USER CONTEXT:
+- Energy pattern: ${args.profile.energyPattern}
+- Biggest blocker: ${args.profile.biggestBlocker}
+- Preferred coaching style: ${args.profile.preferredStyle}
+- Commitment level: ${args.profile.commitmentLevel}
+- Day ${args.profile.dayNumber} of onboarding
+
+CATEGORY: ${args.category}
+${tier.promptFragment.replace("{score}", String(score))}
+
+RECENT SIGNALS (last 5 in this category):
+${signals
+  .slice(-5)
+  .map((signal) => `- ${signal.action} "${signal.itemId}" (${signal.durationMs ?? 0}ms elapsed)`)
+  .join("\n")}
+
+Respond with exactly one JSON object, nothing else:
+{
+  "content": "The suggestion text shown to the user",
+  "reasoning": "Internal reasoning — not shown to user",
+  "confidence": <number 0-100>
+}
+  `.trim();
+}
+
+export function getAssignmentItemId(assignmentId: Id<"aiOnboardingActivityAssignments">) {
+  return assignmentId as string;
+}

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -1,6 +1,26 @@
 import { defineSchema } from "convex/server";
 
 import {
+  aiOnboardingActivityAssignmentTable,
+  aiOnboardingActivityEventTable,
+  aiOnboardingActivityReflectionTable,
+  aiOnboardingActivityTemplateTable,
+  aiOnboardingActivityActionValidator,
+  aiOnboardingBiggestBlockerValidator,
+  aiOnboardingCategoryValidator,
+  aiOnboardingCommitmentLevelValidator,
+  aiOnboardingConfidenceScoreTable,
+  aiOnboardingEnergyPatternValidator,
+  aiOnboardingFeedbackTable,
+  aiOnboardingFeedbackVerdictValidator,
+  aiOnboardingPhaseValidator,
+  aiOnboardingPreferredStyleValidator,
+  aiOnboardingPrimaryGoalValidator,
+  aiOnboardingProfileTable,
+  aiOnboardingSignalTable,
+  aiOnboardingSuggestionTable,
+} from "./schema/aiOnboarding";
+import {
   aiDomainValidator,
   aiMemoryConfidenceValidator,
   aiMemoryTable,
@@ -16,6 +36,17 @@ import {
   userProfilePlanningStyleValidator,
   userProfileTable,
 } from "./schema/onboarding";
+export {
+  aiOnboardingActivityActionValidator,
+  aiOnboardingBiggestBlockerValidator,
+  aiOnboardingCategoryValidator,
+  aiOnboardingCommitmentLevelValidator,
+  aiOnboardingEnergyPatternValidator,
+  aiOnboardingFeedbackVerdictValidator,
+  aiOnboardingPhaseValidator,
+  aiOnboardingPreferredStyleValidator,
+  aiOnboardingPrimaryGoalValidator,
+} from "./schema/aiOnboarding";
 export {
   aiDomainValidator,
   aiMemoryConfidenceValidator,
@@ -34,4 +65,13 @@ export default defineSchema({
   approvalRequests: approvalRequestsTable,
   userProfile: userProfileTable,
   onboardingState: onboardingStateTable,
-  });
+  aiOnboardingProfiles: aiOnboardingProfileTable,
+  aiOnboardingSignals: aiOnboardingSignalTable,
+  aiOnboardingSuggestions: aiOnboardingSuggestionTable,
+  aiOnboardingFeedback: aiOnboardingFeedbackTable,
+  aiOnboardingConfidenceScores: aiOnboardingConfidenceScoreTable,
+  aiOnboardingActivityTemplates: aiOnboardingActivityTemplateTable,
+  aiOnboardingActivityAssignments: aiOnboardingActivityAssignmentTable,
+  aiOnboardingActivityEvents: aiOnboardingActivityEventTable,
+  aiOnboardingActivityReflections: aiOnboardingActivityReflectionTable,
+});

--- a/packages/backend/convex/schema/aiOnboarding.ts
+++ b/packages/backend/convex/schema/aiOnboarding.ts
@@ -1,0 +1,214 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export const aiOnboardingPrimaryGoalValidator = v.union(
+  v.literal("productivity"),
+  v.literal("wellbeing"),
+  v.literal("habits"),
+  v.literal("health"),
+);
+
+export const aiOnboardingEnergyPatternValidator = v.union(
+  v.literal("morning"),
+  v.literal("afternoon"),
+  v.literal("evening"),
+  v.literal("variable"),
+);
+
+export const aiOnboardingBiggestBlockerValidator = v.union(
+  v.literal("follow_through"),
+  v.literal("distraction"),
+  v.literal("overwhelm"),
+  v.literal("energy"),
+);
+
+export const aiOnboardingPreferredStyleValidator = v.union(
+  v.literal("gentle"),
+  v.literal("direct"),
+  v.literal("structured"),
+);
+
+export const aiOnboardingCommitmentLevelValidator = v.union(
+  v.literal("light"),
+  v.literal("moderate"),
+  v.literal("committed"),
+);
+
+export const aiOnboardingCategoryValidator = v.union(
+  v.literal("focus"),
+  v.literal("sleep"),
+  v.literal("exercise"),
+  v.literal("tasks"),
+  v.literal("habits"),
+  v.literal("reflection"),
+);
+
+export const aiOnboardingPhaseValidator = v.union(
+  v.literal("seed"),
+  v.literal("learn"),
+  v.literal("act"),
+);
+
+export const aiOnboardingActivityDifficultyValidator = v.union(
+  v.literal("easy"),
+  v.literal("medium"),
+  v.literal("hard"),
+);
+
+export const aiOnboardingActivityStatusValidator = v.union(
+  v.literal("pending"),
+  v.literal("completed"),
+  v.literal("skipped"),
+);
+
+export const aiOnboardingActivitySourceValidator = v.union(
+  v.literal("hardcoded"),
+  v.literal("ai_generated"),
+);
+
+export const aiOnboardingAssignmentSourceValidator = v.union(
+  v.literal("system"),
+  v.literal("ai"),
+);
+
+export const aiOnboardingActivityActionValidator = v.union(
+  v.literal("viewed"),
+  v.literal("started"),
+  v.literal("completed"),
+  v.literal("skipped"),
+  v.literal("reflected"),
+);
+
+export const aiOnboardingFeedbackVerdictValidator = v.union(
+  v.literal("accepted"),
+  v.literal("dismissed"),
+  v.literal("snoozed"),
+);
+
+export const aiOnboardingProfileAnswersValidator = v.object({
+  primaryGoal: aiOnboardingPrimaryGoalValidator,
+  energyPattern: aiOnboardingEnergyPatternValidator,
+  biggestBlocker: aiOnboardingBiggestBlockerValidator,
+  preferredStyle: aiOnboardingPreferredStyleValidator,
+  commitmentLevel: aiOnboardingCommitmentLevelValidator,
+});
+
+export const aiOnboardingSignalDefinitionValidator = v.object({
+  category: aiOnboardingCategoryValidator,
+  action: aiOnboardingActivityActionValidator,
+  weight: v.number(),
+});
+
+export const aiOnboardingProfileTable = defineTable({
+  userId: v.string(),
+  primaryGoal: aiOnboardingPrimaryGoalValidator,
+  energyPattern: aiOnboardingEnergyPatternValidator,
+  biggestBlocker: aiOnboardingBiggestBlockerValidator,
+  preferredStyle: aiOnboardingPreferredStyleValidator,
+  commitmentLevel: aiOnboardingCommitmentLevelValidator,
+  timezone: v.string(),
+  dayNumber: v.number(),
+  seedAnswers: aiOnboardingProfileAnswersValidator,
+  createdAt: v.number(),
+  updatedAt: v.number(),
+}).index("by_userId", ["userId"]);
+
+export const aiOnboardingSignalTable = defineTable({
+  userId: v.string(),
+  category: aiOnboardingCategoryValidator,
+  action: aiOnboardingActivityActionValidator,
+  itemId: v.string(),
+  durationMs: v.optional(v.number()),
+  metadata: v.optional(v.any()),
+  createdAt: v.number(),
+})
+  .index("by_userId", ["userId"])
+  .index("by_userId_category", ["userId", "category"]);
+
+export const aiOnboardingSuggestionTable = defineTable({
+  userId: v.string(),
+  category: aiOnboardingCategoryValidator,
+  content: v.string(),
+  reasoning: v.optional(v.string()),
+  confidenceAtTime: v.number(),
+  phase: aiOnboardingPhaseValidator,
+  shownAt: v.number(),
+}).index("by_userId", ["userId"]);
+
+export const aiOnboardingFeedbackTable = defineTable({
+  suggestionId: v.id("aiOnboardingSuggestions"),
+  userId: v.string(),
+  verdict: aiOnboardingFeedbackVerdictValidator,
+  reason: v.optional(v.string()),
+  createdAt: v.number(),
+})
+  .index("by_suggestionId", ["suggestionId"])
+  .index("by_userId", ["userId"]);
+
+export const aiOnboardingConfidenceScoreTable = defineTable({
+  userId: v.string(),
+  category: aiOnboardingCategoryValidator,
+  score: v.number(),
+  signalCount: v.number(),
+  acceptCount: v.number(),
+  dismissCount: v.number(),
+  updatedAt: v.number(),
+})
+  .index("by_userId", ["userId"])
+  .index("by_userId_category", ["userId", "category"]);
+
+export const aiOnboardingActivityTemplateTable = defineTable({
+  slug: v.string(),
+  title: v.string(),
+  category: aiOnboardingCategoryValidator,
+  difficulty: aiOnboardingActivityDifficultyValidator,
+  source: aiOnboardingActivitySourceValidator,
+  durationMinutes: v.number(),
+  instructions: v.string(),
+  signalMap: v.record(v.string(), aiOnboardingSignalDefinitionValidator),
+  isHardcoded: v.boolean(),
+  goalTargets: v.array(aiOnboardingPrimaryGoalValidator),
+  energyTargets: v.array(aiOnboardingEnergyPatternValidator),
+  minDayNumber: v.optional(v.number()),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+})
+  .index("by_slug", ["slug"])
+  .index("by_isHardcoded", ["isHardcoded"]);
+
+export const aiOnboardingActivityAssignmentTable = defineTable({
+  userId: v.string(),
+  templateId: v.id("aiOnboardingActivityTemplates"),
+  dayNumber: v.number(),
+  status: aiOnboardingActivityStatusValidator,
+  phase: aiOnboardingPhaseValidator,
+  assignedBy: aiOnboardingAssignmentSourceValidator,
+  assignedAt: v.number(),
+  dueAt: v.number(),
+  completedAt: v.optional(v.number()),
+  skippedAt: v.optional(v.number()),
+})
+  .index("by_userId", ["userId"])
+  .index("by_userId_day", ["userId", "dayNumber"]);
+
+export const aiOnboardingActivityEventTable = defineTable({
+  assignmentId: v.id("aiOnboardingActivityAssignments"),
+  userId: v.string(),
+  action: aiOnboardingActivityActionValidator,
+  elapsedMs: v.number(),
+  metadata: v.optional(v.any()),
+  createdAt: v.number(),
+})
+  .index("by_assignmentId", ["assignmentId"])
+  .index("by_userId", ["userId"]);
+
+export const aiOnboardingActivityReflectionTable = defineTable({
+  assignmentId: v.id("aiOnboardingActivityAssignments"),
+  userId: v.string(),
+  difficultyRating: v.optional(v.number()),
+  usefulnessRating: v.optional(v.number()),
+  note: v.optional(v.string()),
+  createdAt: v.number(),
+})
+  .index("by_assignmentId", ["assignmentId"])
+  .index("by_userId", ["userId"]);


### PR DESCRIPTION
### Motivation
- Implement the 7-day AI onboarding flow described in the design doc by providing first-class storage and APIs for profiles, signals, suggestions, feedback, confidence scoring, and activity lifecycle. 
- Capture the decision to keep confidence per-category and make activities the primary signal engine so AI suggestions can safely escalate from `seed` → `learn` → `act`.

### Description
- Add a new Convex schema `aiOnboarding` with tables for profiles, signals, suggestions, feedback, confidence scores, activity templates, assignments, events, and reflections in `packages/backend/convex/schema/aiOnboarding.ts` and register them in `packages/backend/convex/schema.ts`.
- Implement reusable helpers and constants (questions, hardcoded Day 1–2 templates, tiers, prompt builder, decay function, matching/assignment helpers) in `packages/backend/convex/lib/aiOnboarding.ts`.
- Add Convex query/mutation surface in `packages/backend/convex/aiOnboarding.ts` providing: onboarding question retrieval, `completeAiOnboarding`, `advanceDay`, template seeding, assignment generation, `createSuggestion`, `recordSuggestionFeedback`, `recordActivityEvent`, `recordReflection`, and `getDailyAIContext` with prompt previews and confidence updates.
- Implement confidence update logic (recency decay + acceptance ratio bonus) and day/phase mapping to support the documented AI prompting strategy and activity assignment flow.

### Testing
- Ran `git diff --check` to validate there are no whitespace or index issues, which passed successfully.
- Ran a TypeScript check with `bunx tsc -p packages/backend/convex/tsconfig.json`, which failed early due to missing workspace/module dependencies in this environment (module resolution errors for `convex` and other workspace packages), so a full typecheck could not complete here; recommendation: run `bunx tsc -p packages/backend/convex/tsconfig.json` or `npx convex dev` in CI or a dev environment with dependencies installed to validate types and generated API surfaces.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd6658ce648321849f4670973d83a5)